### PR TITLE
Add `list all` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Features
 
-* **List items** — display the names of clusters, users or contexts.
+* **List items** — display the names of clusters, users or contexts, or list all at once.
 * **Delete items** — remove specific clusters, users or contexts.
 * **Rename items** — rename clusters, users or contexts and automatically update all references, including the `current-context`.
 * **Prune config** — remove clusters and users that are not referenced by any context.
@@ -55,12 +55,13 @@ Below is a quick reference. Run `kedit <command> --help` for the full syntax of 
 
 #### list
 
-List the names of clusters, users or contexts.
+List the names of clusters, users, contexts, or all of them at once.
 
 ```bash
 kedit list cluster
 kedit list user
 kedit list context
+kedit list all
 ```
 
 #### delete

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -10,16 +10,17 @@ import (
 // listCmd represents the list command
 var listCmd = &cobra.Command{
 	// Updated Use string to show type options directly
-	Use:   "list (cluster|user|context)",
-	Short: "List names of a specific type (cluster, user, or context)",
+	Use:   "list (cluster|user|context|all)",
+	Short: "List names of a specific type (cluster, user, context, or all)",
 	Long: `List names of a specific item type within the target kubeconfig file.
 The first argument specifies the type of item to list:
   cluster    List all cluster names.
   user       List all user names.
-  context    List all context names.`,
+  context    List all context names.
+  all        List all clusters, users and contexts.`,
 	Args: cobra.ExactArgs(1), // Requires exactly one argument which is the type
 	RunE: func(cmd *cobra.Command, args []string) error {
-		listType := args[0] // Will be "cluster", "user", or "context"
+		listType := args[0] // Will be "cluster", "user", "context", or "all"
 
 		config, err := loadKubeconfig(resolvedKubeconfigPath)
 		if err != nil {
@@ -69,10 +70,52 @@ The first argument specifies the type of item to list:
 			for _, name := range names {
 				fmt.Printf("- %s\n", name)
 			}
+		case "all":
+			if len(config.Clusters) == 0 {
+				fmt.Println("No clusters found.")
+			} else {
+				clusterNames := make([]string, 0, len(config.Clusters))
+				for name := range config.Clusters {
+					clusterNames = append(clusterNames, name)
+				}
+				sort.Strings(clusterNames)
+				fmt.Println("Clusters:")
+				for _, name := range clusterNames {
+					fmt.Printf("- %s\n", name)
+				}
+			}
+
+			if len(config.AuthInfos) == 0 {
+				fmt.Println("No users found.")
+			} else {
+				userNames := make([]string, 0, len(config.AuthInfos))
+				for name := range config.AuthInfos {
+					userNames = append(userNames, name)
+				}
+				sort.Strings(userNames)
+				fmt.Println("Users:")
+				for _, name := range userNames {
+					fmt.Printf("- %s\n", name)
+				}
+			}
+
+			if len(config.Contexts) == 0 {
+				fmt.Println("No contexts found.")
+			} else {
+				contextNames := make([]string, 0, len(config.Contexts))
+				for name := range config.Contexts {
+					contextNames = append(contextNames, name)
+				}
+				sort.Strings(contextNames)
+				fmt.Println("Contexts:")
+				for _, name := range contextNames {
+					fmt.Printf("- %s\n", name)
+				}
+			}
 		default:
 			// This case should ideally not be reached if Cobra validates based on Use line,
 			// but good for robustness and if Use line is manually typed wrong by user.
-			return fmt.Errorf("invalid type '%s'. Must be one of: cluster, user, context", listType)
+			return fmt.Errorf("invalid type '%s'. Must be one of: cluster, user, context, all", listType)
 		}
 		return nil
 	},


### PR DESCRIPTION
## Summary
- add `all` option to `list` command
- show how to use `list all` in documentation

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68403cf848e4832dab17196dc782300c